### PR TITLE
Noop appendentry - LogEntry(Option[A]...) approach

### DIFF
--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -4,10 +4,10 @@
 // This plugin enables semantic information to be produced by sbt.
 // It also adds support for debugging using the Debug Adapter Protocol
 
-addSbtPlugin("org.scalameta" % "sbt-metals" % "1.6.0")
+addSbtPlugin("org.scalameta" % "sbt-metals" % "1.6.2")
 
 // This plugin adds the BSP debug capability to sbt server.
 
-addSbtPlugin("ch.epfl.scala" % "sbt-debug-adapter" % "4.2.5")
+addSbtPlugin("ch.epfl.scala" % "sbt-debug-adapter" % "4.2.8")
 
 // format: on

--- a/raft-zmq/src/test/scala/zio/raft/zmq/MessageCodecSpec.scala
+++ b/raft-zmq/src/test/scala/zio/raft/zmq/MessageCodecSpec.scala
@@ -20,7 +20,7 @@ object MessageCodecSpec extends ZIOSpecDefault:
       leaderId = MemberId("leader"),
       previousIndex = Index.zero,
       previousTerm = Term.zero,
-      entries = List(LogEntry(TestCommand("test"), Term.zero, Index.one)),
+      entries = List(LogEntry.command(TestCommand("test"), Term.zero, Index.one)),
       leaderCommitIndex = Index.zero
     )
 

--- a/raft/src/main/scala/zio/raft/LogStore.scala
+++ b/raft/src/main/scala/zio/raft/LogStore.scala
@@ -48,7 +48,7 @@ object LogStore:
       logs.update(_.filter(e => e.index >= index))
 
     override def discardEntireLog(previousIndex: Index, previousTerm: Term): UIO[Unit] =
-      logs.set(LogEntry(null.asInstanceOf, previousTerm, previousIndex) :: List.empty[LogEntry[A]])
+      logs.set(LogEntry.noop(previousTerm, previousIndex) :: List.empty[LogEntry[A]])
 
     override def lastIndex = logs.get.map(_.headOption.map(_.index).getOrElse(Index.zero))
     override def lastTerm = logs.get.map(_.headOption.map(_.term).getOrElse(Term.zero))

--- a/raft/src/main/scala/zio/raft/Types.scala
+++ b/raft/src/main/scala/zio/raft/Types.scala
@@ -58,11 +58,11 @@ case class NotALeaderError(leaderId: Option[MemberId])
 type CommandPromise[A] = Promise[NotALeaderError, A]
 
 case class EntryKey(term: Term, index: Index)
-case class LogEntry[A <: Command](command: Option[A], term: Term, index: Index)
+case class LogEntry[+A <: Command](command: Option[A], term: Term, index: Index)
 
 object LogEntry:
   def command[A <: Command](command: A, term: Term, index: Index) = LogEntry(Some(command), term, index)
-  def noop(term: Term, index: Index) = LogEntry(None, term, index)
+  def noop(term: Term, index: Index) = LogEntry[Nothing](None, term, index)
 
 sealed trait RPCMessage[A <: Command]:
   val term: Term

--- a/raft/src/main/scala/zio/raft/Types.scala
+++ b/raft/src/main/scala/zio/raft/Types.scala
@@ -58,7 +58,11 @@ case class NotALeaderError(leaderId: Option[MemberId])
 type CommandPromise[A] = Promise[NotALeaderError, A]
 
 case class EntryKey(term: Term, index: Index)
-case class LogEntry[A <: Command](command: A, term: Term, index: Index)
+case class LogEntry[A <: Command](command: Option[A], term: Term, index: Index)
+
+object LogEntry:
+  def command[A <: Command](command: A, term: Term, index: Index) = LogEntry(Some(command), term, index)
+  def noop(term: Term, index: Index) = LogEntry(None, term, index)
 
 sealed trait RPCMessage[A <: Command]:
   val term: Term

--- a/raft/src/test/scala/zio/raft/RaftSpec.scala
+++ b/raft/src/test/scala/zio/raft/RaftSpec.scala
@@ -111,10 +111,7 @@ object RaftSpec extends ZIOSpecDefault:
   def sendCommand(raft: Raft[Int, TestCommands], commandArg: TestCommands) =
     for
       promiseArg <- zio.Promise.make[NotALeaderError, Int]
-      _ <- raft.handleStreamItem(new CommandMessage[TestCommands, Int] {
-        val command: TestCommands = commandArg
-        val promise: CommandPromise[Int] = promiseArg
-      })
+      _ <- raft.handleStreamItem(CommandMessage.command(commandArg, promiseArg))
     yield ()
 
   def bootstrap(raft: Raft[Int, TestCommands]) =

--- a/raft/src/test/scala/zio/raft/RaftSpec.scala
+++ b/raft/src/test/scala/zio/raft/RaftSpec.scala
@@ -228,11 +228,7 @@ object RaftSpec extends ZIOSpecDefault:
           Array(MemberId("peer2"), MemberId("peer3")),
           false
         )
-        logEntry: LogEntry[TestCommands] = LogEntry(
-          Increase,
-          Term(1),
-          Index(1)
-        )
+        logEntry: LogEntry[TestCommands] = LogEntry.command(Increase, Term(1), Index(1))
         _ <- handelAppendEntries(
           raft,
           Term(1),
@@ -268,7 +264,7 @@ object RaftSpec extends ZIOSpecDefault:
           MemberId("peer1"),
           Index(0),
           Term(0),
-          List(LogEntry(Increase, Term(1), Index(1))),
+          List(LogEntry.command(Increase, Term(1), Index(1))),
           Index(0)
         )
         expectedMessages = List(
@@ -291,7 +287,7 @@ object RaftSpec extends ZIOSpecDefault:
           MemberId("peer2"),
           Index(0),
           Term(0),
-          List(LogEntry(Increase, Term(1), Index(1))),
+          List(LogEntry.command(Increase, Term(1), Index(1))),
           Index(0)
         )
 

--- a/stores/src/main/scala/zio/raft/stores/segmentedlog/internal.scala
+++ b/stores/src/main/scala/zio/raft/stores/segmentedlog/internal.scala
@@ -4,7 +4,7 @@ import zio.raft.{Command, Index, LogEntry, Term}
 import zio.{Scope, ScopedRef, ZIO}
 
 import scodec.Codec
-import scodec.codecs.{constant, int64, uint16, uint32, int32, bool}
+import scodec.codecs.{constant, int64, uint16, uint32, int32, bool, optional}
 
 object internal:
   val entrySizeCodec = int32
@@ -14,7 +14,9 @@ object internal:
   private def termCodec = int64.xmap(Term(_), _.value)
   private def indexCodec = int64.xmap(Index(_), _.value)
 
-  def entryCodec[A <: Command](using codec: Codec[A]): Codec[LogEntry[A]] =
+  def optionalCommandCodec[A <: Command](using codec: Codec[A]): Codec[Option[A]] = optional(bool(8), codec)
+
+  def entryCodec[A <: Command](using codec: Codec[Option[A]]): Codec[LogEntry[A]] =
     (codec :: termCodec :: indexCodec).as[LogEntry[A]]
   def entriesCodec[A <: Command: Codec]: ChecksummedList[LogEntry[A]] =
     new ChecksummedList[LogEntry[A]](entryCodec)

--- a/stores/src/test/scala/zio/raft/stores/segmentedlog/SegmentedLogSpec.scala
+++ b/stores/src/test/scala/zio/raft/stores/segmentedlog/SegmentedLogSpec.scala
@@ -23,7 +23,7 @@ object SegmentedLogSpec extends ZIOSpecDefault:
         logDirectory <- tempDirectory
         log <- SegmentedLog.make[TestCommand](logDirectory.toString())
         command <- TestCommand.generator.runHead.someOrFail(new Exception("No command"))
-        logEntry = LogEntry[TestCommand](command, Term.one, Index.one)
+        logEntry = LogEntry.command(command, Term.one, Index.one)
         _ <- log.storeLog(logEntry)
         entries <- log.getLogs(Index.one, Index.one)
       yield assertTrue(entries.head.head == logEntry && entries.size == 1)
@@ -34,7 +34,7 @@ object SegmentedLogSpec extends ZIOSpecDefault:
           logDirectory <- tempDirectory
           log <- SegmentedLog.make[TestCommand](logDirectory.toString(), maxLogFileSize = 1024)
           entries = commands.zipWithIndex.map((command, index) =>
-            LogEntry[TestCommand](command, Term.one, Index(index.toLong + 1))
+            LogEntry.command(command, Term.one, Index(index.toLong + 1))
           )
           _ <- log.storeLogs(entries)
 
@@ -48,7 +48,7 @@ object SegmentedLogSpec extends ZIOSpecDefault:
           logDirectory <- tempDirectory
           log <- SegmentedLog.make[TestCommand](logDirectory.toString())
           command <- TestCommand.generator.runHead.someOrFail(new Exception("No command"))
-          logEntry = LogEntry[TestCommand](command, Term.one, Index.one)
+          logEntry = LogEntry.command(command, Term.one, Index.one)
           _ <- log.storeLog(logEntry)
           term <- log.logTerm(Index.zero)
         yield assertTrue(term.get == Term.zero)
@@ -58,7 +58,7 @@ object SegmentedLogSpec extends ZIOSpecDefault:
           logDirectory <- tempDirectory
           log <- SegmentedLog.make[TestCommand](logDirectory.toString())
           command <- TestCommand.generator.runHead.someOrFail(new Exception("No command"))
-          logEntry = LogEntry[TestCommand](command, Term.one, Index.one)
+          logEntry = LogEntry.command(command, Term.one, Index.one)
           _ <- log.storeLog(logEntry)
           term <- log.logTerm(Index.one)
         yield assertTrue(term.get == Term.one)
@@ -68,13 +68,13 @@ object SegmentedLogSpec extends ZIOSpecDefault:
           logDirectory <- tempDirectory
           log <- SegmentedLog.make[TestCommand](logDirectory.toString())
           command <- TestCommand.generator.runHead.someOrFail(new Exception("No command"))
-          logEntry = LogEntry[TestCommand](command, Term.one, Index.one)
+          logEntry = LogEntry.command(command, Term.one, Index.one)
           _ <- log.storeLog(logEntry)
           command <- TestCommand.generator.runHead.someOrFail(new Exception("No command"))
-          logEntry = LogEntry[TestCommand](command, Term(10L), Index(2L))
+          logEntry = LogEntry.command(command, Term(10L), Index(2L))
           _ <- log.storeLog(logEntry)
           command <- TestCommand.generator.runHead.someOrFail(new Exception("No command"))
-          logEntry = LogEntry[TestCommand](command, Term(30L), Index(3L))
+          logEntry = LogEntry.command(command, Term(30L), Index(3L))
           _ <- log.storeLog(logEntry)
 
           term <- log.logTerm(Index(2))
@@ -89,7 +89,7 @@ object SegmentedLogSpec extends ZIOSpecDefault:
         // Create entries that will exceed the max size
         commands <- Gen.listOfBounded(5, 10)(TestCommand.generator).runHead.someOrFail(new Exception("No commands"))
         entries = commands.zipWithIndex.map((command, index) =>
-          LogEntry[TestCommand](command, Term.one, Index(index.toLong + 1))
+          LogEntry.command(command, Term.one, Index(index.toLong + 1))
         )
 
         // Store entries which should trigger segment rollover
@@ -120,7 +120,7 @@ object SegmentedLogSpec extends ZIOSpecDefault:
           log <- SegmentedLog.make[TestCommand](logDirectory.toString(), maxLogFileSize = 100)
           commands <- Gen.listOfBounded(5, 10)(TestCommand.generator).runHead.someOrFail(new Exception("No commands"))
           entries = commands.zipWithIndex.map((command, index) =>
-            LogEntry[TestCommand](command, Term.one, Index(index.toLong + 1))
+            LogEntry.command(command, Term.one, Index(index.toLong + 1))
           )
           _ <- log.storeLogs(entries)
           recoveredLog <- SegmentedLog.make[TestCommand](logDirectory.toString(), maxLogFileSize = 100)
@@ -146,7 +146,7 @@ object SegmentedLogSpec extends ZIOSpecDefault:
           log <- SegmentedLog.make[TestCommand](logDirectory.toString(), maxLogFileSize = 100)
           commands <- Gen.listOfBounded(5, 10)(TestCommand.generator).runHead.someOrFail(new Exception("No commands"))
           entries = commands.zipWithIndex.map((command, index) =>
-            LogEntry[TestCommand](command, Term.one, Index(index.toLong + 1))
+            LogEntry.command(command, Term.one, Index(index.toLong + 1))
           )
           _ <- log.storeLogs(entries)
           // Recover with larger segment size


### PR DESCRIPTION
Simpler design ([Other design ](https://github.com/unit-finance/zio-raft/pull/11)) to the noop command leadership validation, this uses None for a noop command, it is less explicit and requires less modifications 