### PR TITLE
fix flaky tests because of ZTestLogger

### DIFF
--- a/raft/src/test/scala/zio/raft/RaftIntegrationSpec.scala
+++ b/raft/src/test/scala/zio/raft/RaftIntegrationSpec.scala
@@ -19,7 +19,7 @@ object RaftIntegrationSpec extends ZIOSpecDefault:
 
   // We use TestLogger instead of ZTestLogger because ZTestLogger can cause duplicated log lines which causes flakiness in our tests.
   class TestLogger extends ZLogger[String, Unit] {
-    var messages: ConcurrentLinkedQueue[String] = new ConcurrentLinkedQueue()
+    val messages: ConcurrentLinkedQueue[String] = new ConcurrentLinkedQueue()
     override def apply(trace: Trace, fiberId: FiberId, logLevel: LogLevel, message: () => String, cause: Cause[Any], context: FiberRefs, spans: List[LogSpan], annotations: Map[String, String]): Unit =
       messages.add(message())
     


### PR DESCRIPTION
One test was fixed by moving away from ZTestLogger, as ZTestLogger can cause duplicated log lines.
also identified why another test is flaky and added a TODO comment and TestAspect.flaky, until we find a better way to test it