### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: publish
+permissions:
+  contents: read
 on:
   release:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/unit-finance/zio-raft/security/code-scanning/2](https://github.com/unit-finance/zio-raft/security/code-scanning/2)

To fix the problem, add a `permissions:` block to the workflow. The most conservative place for this is at the root of the YAML file, which protects all jobs (here, there is only one: `build`). Add the following line after `name: publish` (or right after the `on: ...` block), setting `permissions: contents: read`. This grants the minimal required read access to repository contents, which is usually sufficient for checking out code. No existing functionality will break, as none of the steps require write access to the repository or GitHub APIs. You do not need to add any imports, definitions, or method changes—just the YAML block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
